### PR TITLE
Target 32 and 64 bit architectures in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ language: c
 addons:
   apt:
     packages:
-     - gcc-multilib
      - binutils-mingw-w64-i686
      - binutils-mingw-w64-x86-64
-     - mingw-w64-dev
-     - gcc-mingw-w64-base
+     - gcc-multilib
      - gcc-mingw-w64-i686
      - gcc-mingw-w64-x86-64
-     - wine1.4-common
-     - wine1.4-i386
-     - wine1.4-amd64
      - wine1.4
 script:
  - CC=clang CFLAGS=-m32 make clean check

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,20 @@ language: c
 addons:
   apt:
     packages:
+     - gcc-multilib
      - binutils-mingw-w64-i686
+     - binutils-mingw-w64-x86-64
      - mingw-w64-dev
      - gcc-mingw-w64-base
      - gcc-mingw-w64-i686
+     - gcc-mingw-w64-x86-64
      - wine1.4-common
      - wine1.4-i386
+     - wine1.4-amd64
      - wine1.4
 script:
- - make clean check CC=clang
- - make clean check CC=gcc
- - make clean check -f Makefile.msys CC=i686-w64-mingw32-gcc RUN=wine
+ - CC=clang CFLAGS=-m32 make clean check
+ - CC=clang CFLAGS=-m64 make clean check
+ - CC=gcc               make clean check
+ - CC=i686-w64-mingw32-gcc   RUN=wine   make clean check -f Makefile.msys
+ - CC=x86_64-w64-mingw32-gcc RUN=wine64 make clean check -f Makefile.msys

--- a/Makefile.msys
+++ b/Makefile.msys
@@ -1,9 +1,9 @@
 CFLAGS += -std=c89 -Wall
 LDLIBS += -lws2_32
 
-#RUN = wine
-RUN  =
-DIFF = diff -uw
+#RUN ?= wine
+RUN  ?=
+DIFF ?= diff -uw
 
 all: jsinc.exe
 


### PR DESCRIPTION
Not for the GCC build, that just exists to make sure the project compiles with GCC at all.